### PR TITLE
[UPDATE] Enum key name and enum entries use

### DIFF
--- a/lib/src/main/kotlin/dev/hossain/android/catalogparser/Parser.kt
+++ b/lib/src/main/kotlin/dev/hossain/android/catalogparser/Parser.kt
@@ -68,7 +68,7 @@ class Parser {
                 }
 
                 // Convert form factor string to enum, skip record if unknown
-                val formFactor = FormFactor.fromCsvValueOrNull(formFactorString)
+                val formFactor = FormFactor.fromValueOrNull(formFactorString)
                 if (formFactor == null) {
                     // Log or handle unknown form factor - for now, skip the record
                     return@map null

--- a/lib/src/main/kotlin/dev/hossain/android/catalogparser/models/FormFactor.kt
+++ b/lib/src/main/kotlin/dev/hossain/android/catalogparser/models/FormFactor.kt
@@ -121,27 +121,27 @@ enum class FormFactor(
         /**
          * Returns the FormFactor enum value that matches the given CSV value.
          *
-         * @param csvValue The string value from the CSV data
+         * @param value The string value from the CSV data
          * @return The corresponding FormFactor enum value
          * @throws IllegalArgumentException if the CSV value doesn't match any known form factor
          */
-        fun fromCsvValue(csvValue: String): FormFactor =
-            entries.find { it.value == csvValue }
-                ?: throw IllegalArgumentException("Unknown form factor: $csvValue")
+        fun fromValue(value: String): FormFactor =
+            entries.find { it.value == value }
+                ?: throw IllegalArgumentException("Unknown form factor: $value")
 
         /**
          * Returns the FormFactor enum value that matches the given CSV value, or null if not found.
          *
-         * @param csvValue The string value from the CSV data
+         * @param value The string value from the CSV data
          * @return The corresponding FormFactor enum value, or null if not found
          */
-        fun fromCsvValueOrNull(csvValue: String): FormFactor? = entries.find { it.value == csvValue }
+        fun fromValueOrNull(value: String): FormFactor? = entries.find { it.value == value }
 
         /**
          * Returns all CSV values as a list for validation or reference purposes.
          *
          * @return List of all valid CSV values
          */
-        fun getAllCsvValues(): List<String> = entries.map { it.value }
+        fun getAllValues(): List<String> = entries.map { it.value }
     }
 }

--- a/lib/src/main/kotlin/dev/hossain/android/catalogparser/models/FormFactor.kt
+++ b/lib/src/main/kotlin/dev/hossain/android/catalogparser/models/FormFactor.kt
@@ -12,7 +12,7 @@ enum class FormFactor(
     /**
      * The string value as it appears in the CSV data from Google Play Device Catalog.
      */
-    val csvValue: String,
+    val value: String,
     /**
      * A human-readable description of this form factor.
      */
@@ -126,7 +126,7 @@ enum class FormFactor(
          * @throws IllegalArgumentException if the CSV value doesn't match any known form factor
          */
         fun fromCsvValue(csvValue: String): FormFactor =
-            values().find { it.csvValue == csvValue }
+            entries.find { it.value == csvValue }
                 ?: throw IllegalArgumentException("Unknown form factor: $csvValue")
 
         /**
@@ -135,13 +135,13 @@ enum class FormFactor(
          * @param csvValue The string value from the CSV data
          * @return The corresponding FormFactor enum value, or null if not found
          */
-        fun fromCsvValueOrNull(csvValue: String): FormFactor? = values().find { it.csvValue == csvValue }
+        fun fromCsvValueOrNull(csvValue: String): FormFactor? = entries.find { it.value == csvValue }
 
         /**
          * Returns all CSV values as a list for validation or reference purposes.
          *
          * @return List of all valid CSV values
          */
-        fun getAllCsvValues(): List<String> = values().map { it.csvValue }
+        fun getAllCsvValues(): List<String> = entries.map { it.value }
     }
 }

--- a/lib/src/test/kotlin/dev/hossain/android/catalogparser/models/FormFactorTest.kt
+++ b/lib/src/test/kotlin/dev/hossain/android/catalogparser/models/FormFactorTest.kt
@@ -11,40 +11,40 @@ import kotlin.test.assertNull
 class FormFactorTest {
     @Test
     fun `fromCsvValue returns correct FormFactor for valid CSV values`() {
-        assertEquals(FormFactor.PHONE, FormFactor.fromCsvValue("Phone"))
-        assertEquals(FormFactor.TABLET, FormFactor.fromCsvValue("Tablet"))
-        assertEquals(FormFactor.TV, FormFactor.fromCsvValue("TV"))
-        assertEquals(FormFactor.WEARABLE, FormFactor.fromCsvValue("Wearable"))
-        assertEquals(FormFactor.ANDROID_AUTOMOTIVE, FormFactor.fromCsvValue("Android Automotive"))
-        assertEquals(FormFactor.CHROMEBOOK, FormFactor.fromCsvValue("Chromebook"))
-        assertEquals(FormFactor.GOOGLE_PLAY_GAMES_ON_PC, FormFactor.fromCsvValue("Google Play Games on PC"))
+        assertEquals(FormFactor.PHONE, FormFactor.fromValue("Phone"))
+        assertEquals(FormFactor.TABLET, FormFactor.fromValue("Tablet"))
+        assertEquals(FormFactor.TV, FormFactor.fromValue("TV"))
+        assertEquals(FormFactor.WEARABLE, FormFactor.fromValue("Wearable"))
+        assertEquals(FormFactor.ANDROID_AUTOMOTIVE, FormFactor.fromValue("Android Automotive"))
+        assertEquals(FormFactor.CHROMEBOOK, FormFactor.fromValue("Chromebook"))
+        assertEquals(FormFactor.GOOGLE_PLAY_GAMES_ON_PC, FormFactor.fromValue("Google Play Games on PC"))
     }
 
     @Test
     fun `fromCsvValue throws IllegalArgumentException for invalid CSV value`() {
         val exception =
             assertFailsWith<IllegalArgumentException> {
-                FormFactor.fromCsvValue("Invalid Form Factor")
+                FormFactor.fromValue("Invalid Form Factor")
             }
         assertEquals("Unknown form factor: Invalid Form Factor", exception.message)
     }
 
     @Test
     fun `fromCsvValueOrNull returns correct FormFactor for valid CSV values`() {
-        assertEquals(FormFactor.PHONE, FormFactor.fromCsvValueOrNull("Phone"))
-        assertEquals(FormFactor.TABLET, FormFactor.fromCsvValueOrNull("Tablet"))
-        assertEquals(FormFactor.TV, FormFactor.fromCsvValueOrNull("TV"))
-        assertEquals(FormFactor.WEARABLE, FormFactor.fromCsvValueOrNull("Wearable"))
-        assertEquals(FormFactor.ANDROID_AUTOMOTIVE, FormFactor.fromCsvValueOrNull("Android Automotive"))
-        assertEquals(FormFactor.CHROMEBOOK, FormFactor.fromCsvValueOrNull("Chromebook"))
-        assertEquals(FormFactor.GOOGLE_PLAY_GAMES_ON_PC, FormFactor.fromCsvValueOrNull("Google Play Games on PC"))
+        assertEquals(FormFactor.PHONE, FormFactor.fromValueOrNull("Phone"))
+        assertEquals(FormFactor.TABLET, FormFactor.fromValueOrNull("Tablet"))
+        assertEquals(FormFactor.TV, FormFactor.fromValueOrNull("TV"))
+        assertEquals(FormFactor.WEARABLE, FormFactor.fromValueOrNull("Wearable"))
+        assertEquals(FormFactor.ANDROID_AUTOMOTIVE, FormFactor.fromValueOrNull("Android Automotive"))
+        assertEquals(FormFactor.CHROMEBOOK, FormFactor.fromValueOrNull("Chromebook"))
+        assertEquals(FormFactor.GOOGLE_PLAY_GAMES_ON_PC, FormFactor.fromValueOrNull("Google Play Games on PC"))
     }
 
     @Test
     fun `fromCsvValueOrNull returns null for invalid CSV value`() {
-        assertNull(FormFactor.fromCsvValueOrNull("Invalid Form Factor"))
-        assertNull(FormFactor.fromCsvValueOrNull(""))
-        assertNull(FormFactor.fromCsvValueOrNull("phone")) // case sensitive
+        assertNull(FormFactor.fromValueOrNull("Invalid Form Factor"))
+        assertNull(FormFactor.fromValueOrNull(""))
+        assertNull(FormFactor.fromValueOrNull("phone")) // case sensitive
     }
 
     @Test
@@ -59,7 +59,7 @@ class FormFactorTest {
                 "Chromebook",
                 "Google Play Games on PC",
             )
-        assertEquals(expectedValues, FormFactor.getAllCsvValues())
+        assertEquals(expectedValues, FormFactor.getAllValues())
     }
 
     @Test
@@ -106,7 +106,7 @@ class FormFactorTest {
 
     @Test
     fun `CSV values are unique`() {
-        val csvValues = FormFactor.getAllCsvValues()
+        val csvValues = FormFactor.getAllValues()
         val uniqueCsvValues = csvValues.toSet()
         assertEquals(csvValues.size, uniqueCsvValues.size, "All CSV values should be unique")
     }

--- a/lib/src/test/kotlin/dev/hossain/android/catalogparser/models/FormFactorTest.kt
+++ b/lib/src/test/kotlin/dev/hossain/android/catalogparser/models/FormFactorTest.kt
@@ -64,25 +64,25 @@ class FormFactorTest {
 
     @Test
     fun `enum values have correct csvValue and description`() {
-        assertEquals("Phone", FormFactor.PHONE.csvValue)
+        assertEquals("Phone", FormFactor.PHONE.value)
         assertEquals("Smartphones and mobile phones", FormFactor.PHONE.description)
 
-        assertEquals("Tablet", FormFactor.TABLET.csvValue)
+        assertEquals("Tablet", FormFactor.TABLET.value)
         assertEquals("Tablet devices with larger screens", FormFactor.TABLET.description)
 
-        assertEquals("TV", FormFactor.TV.csvValue)
+        assertEquals("TV", FormFactor.TV.value)
         assertEquals("Television and Android TV devices", FormFactor.TV.description)
 
-        assertEquals("Wearable", FormFactor.WEARABLE.csvValue)
+        assertEquals("Wearable", FormFactor.WEARABLE.value)
         assertEquals("Smartwatches and other wearable devices", FormFactor.WEARABLE.description)
 
-        assertEquals("Android Automotive", FormFactor.ANDROID_AUTOMOTIVE.csvValue)
+        assertEquals("Android Automotive", FormFactor.ANDROID_AUTOMOTIVE.value)
         assertEquals("In-vehicle Android Automotive systems", FormFactor.ANDROID_AUTOMOTIVE.description)
 
-        assertEquals("Chromebook", FormFactor.CHROMEBOOK.csvValue)
+        assertEquals("Chromebook", FormFactor.CHROMEBOOK.value)
         assertEquals("Chromebook devices running Android apps", FormFactor.CHROMEBOOK.description)
 
-        assertEquals("Google Play Games on PC", FormFactor.GOOGLE_PLAY_GAMES_ON_PC.csvValue)
+        assertEquals("Google Play Games on PC", FormFactor.GOOGLE_PLAY_GAMES_ON_PC.value)
         assertEquals("PC platform for Android games", FormFactor.GOOGLE_PLAY_GAMES_ON_PC.description)
     }
 

--- a/sample/src/main/java/dev/hossain/example/Main.kt
+++ b/sample/src/main/java/dev/hossain/example/Main.kt
@@ -136,7 +136,7 @@ private fun processRecordsToDb(parsedDevices: List<AndroidDevice>) {
                 manufacturer = dbDevice.manufacturer,
                 modelName = dbDevice.model_name,
                 ram = dbDevice.ram,
-                formFactor = FormFactor.fromCsvValue(dbDevice.form_factor),
+                formFactor = FormFactor.fromValue(dbDevice.form_factor),
                 processorName = dbDevice.processor_name,
                 gpu = dbDevice.gpu,
                 screenSizes = deviceQueries.getScreenSize(dbDevice._id).executeAsList().map { it.screen_size },

--- a/sample/src/main/java/dev/hossain/example/Main.kt
+++ b/sample/src/main/java/dev/hossain/example/Main.kt
@@ -50,7 +50,7 @@ fun main() {
     val formFactorCounts = parsedDevices.groupingBy { it.formFactor }.eachCount()
     println("Form factor counts:")
     formFactorCounts.forEach { (formFactor, count) ->
-        println("  \"${formFactor.csvValue}\": $count")
+        println("  \"${formFactor.value}\": $count")
     }
 
     // Write the parsed AndroidDevice objects to a JSON file.
@@ -95,7 +95,7 @@ private fun processRecordsToDb(parsedDevices: List<AndroidDevice>) {
                 manufacturer = androidDevice.manufacturer,
                 model_name = androidDevice.modelName,
                 ram = androidDevice.ram,
-                form_factor = androidDevice.formFactor.csvValue,
+                form_factor = androidDevice.formFactor.value,
                 processor_name = androidDevice.processorName,
                 gpu = androidDevice.gpu,
             )

--- a/sample/src/test/kotlin/dev/hossain/example/DatabaseSchemaTest.kt
+++ b/sample/src/test/kotlin/dev/hossain/example/DatabaseSchemaTest.kt
@@ -10,49 +10,49 @@ import kotlin.test.assertTrue
  * Test cases to verify the database schema constraints work correctly
  */
 class DatabaseSchemaTest {
-
     @Test
     fun `database CHECK constraint rejects invalid form factor values`() {
         // Create an in-memory SQLite database for testing
         val driver: SqlDriver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
         val database = DeviceDatabase(driver)
         DeviceDatabase.Schema.create(driver)
-        
+
         val deviceQueries = database.deviceQueries
-        
+
         // Test that valid form factor values work
         deviceQueries.insert(
             brand = "Test",
             device = "test_device",
-            manufacturer = "Test Manufacturer", 
+            manufacturer = "Test Manufacturer",
             model_name = "Test Model",
             ram = "4GB",
             form_factor = "Phone", // Valid form factor
             processor_name = "Test Processor",
-            gpu = "Test GPU"
+            gpu = "Test GPU",
         )
-        
+
         // Verify the record was inserted
         val devices = deviceQueries.selectAll().executeAsList()
         assertTrue(devices.size == 1)
-        
+
         // Test that invalid form factor values are rejected
-        val exception = assertFailsWith<Exception> {
-            deviceQueries.insert(
-                brand = "Test2",
-                device = "test_device2", 
-                manufacturer = "Test Manufacturer2",
-                model_name = "Test Model2",
-                ram = "8GB",
-                form_factor = "Invalid Form Factor", // Invalid form factor
-                processor_name = "Test Processor2",
-                gpu = "Test GPU2"
-            )
-        }
-        
+        val exception =
+            assertFailsWith<Exception> {
+                deviceQueries.insert(
+                    brand = "Test2",
+                    device = "test_device2",
+                    manufacturer = "Test Manufacturer2",
+                    model_name = "Test Model2",
+                    ram = "8GB",
+                    form_factor = "Invalid Form Factor", // Invalid form factor
+                    processor_name = "Test Processor2",
+                    gpu = "Test GPU2",
+                )
+            }
+
         // Verify the constraint violation message mentions CHECK constraint
         assertTrue(exception.message?.contains("CHECK constraint failed") == true)
-        
+
         // Verify only the valid record exists in the database
         val devicesAfterError = deviceQueries.selectAll().executeAsList()
         assertTrue(devicesAfterError.size == 1)
@@ -63,37 +63,38 @@ class DatabaseSchemaTest {
         val driver: SqlDriver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
         val database = DeviceDatabase(driver)
         DeviceDatabase.Schema.create(driver)
-        
+
         val deviceQueries = database.deviceQueries
-        
+
         // Test all valid form factor values from FormFactor enum
-        val validFormFactors = listOf(
-            "Phone",
-            "Tablet", 
-            "TV",
-            "Wearable",
-            "Android Automotive",
-            "Chromebook",
-            "Google Play Games on PC"
-        )
-        
+        val validFormFactors =
+            listOf(
+                "Phone",
+                "Tablet",
+                "TV",
+                "Wearable",
+                "Android Automotive",
+                "Chromebook",
+                "Google Play Games on PC",
+            )
+
         validFormFactors.forEachIndexed { index, formFactor ->
             deviceQueries.insert(
                 brand = "Test$index",
                 device = "test_device$index",
                 manufacturer = "Test Manufacturer$index",
-                model_name = "Test Model$index", 
+                model_name = "Test Model$index",
                 ram = "${index + 1}GB",
                 form_factor = formFactor,
                 processor_name = "Test Processor$index",
-                gpu = "Test GPU$index"
+                gpu = "Test GPU$index",
             )
         }
-        
+
         // Verify all records were inserted successfully
         val devices = deviceQueries.selectAll().executeAsList()
         assertTrue(devices.size == validFormFactors.size)
-        
+
         // Verify all form factors match what we inserted
         val insertedFormFactors = devices.map { it.form_factor }.toSet()
         assertTrue(insertedFormFactors == validFormFactors.toSet())


### PR DESCRIPTION
This pull request refactors the `FormFactor` enum in the `catalogparser` module by renaming the `csvValue` property to `value` and updating its usages across the codebase. The changes ensure consistency in naming and improve readability. Additionally, associated test cases and sample usage in the `example` module have been updated to reflect this change.

### Refactoring of `FormFactor` Enum:

- **Property Renaming**: Renamed `csvValue` to `value` in `FormFactor` enum to better align with its purpose. Updated all references to this property in methods like `fromCsvValue`, `fromCsvValueOrNull`, and `getAllCsvValues`. (`lib/src/main/kotlin/dev/hossain/android/catalogparser/models/FormFactor.kt`, [[1]](diffhunk://#diff-74b83e4ffff8aa2b0bf9b7da0a9f6e560f40f6086b7168255db4dd3f7b1dd0d0L15-R15) [[2]](diffhunk://#diff-74b83e4ffff8aa2b0bf9b7da0a9f6e560f40f6086b7168255db4dd3f7b1dd0d0L129-R129) [[3]](diffhunk://#diff-74b83e4ffff8aa2b0bf9b7da0a9f6e560f40f6086b7168255db4dd3f7b1dd0d0L138-R145)

### Updates to Tests:

- **FormFactor Tests**: Updated assertions in `FormFactorTest` to use the renamed `value` property instead of `csvValue`. (`lib/src/test/kotlin/dev/hossain/android/catalogparser/models/FormFactorTest.kt`, [lib/src/test/kotlin/dev/hossain/android/catalogparser/models/FormFactorTest.ktL67-R85](diffhunk://#diff-6d1e70f092fdfceea32c88f5caf7d50bd635278d93d3812fede8f1c3eb00a409L67-R85))
- **DatabaseSchema Tests**: Adjusted formatting and added trailing commas for better readability in test cases verifying database constraints and valid form factors. (`sample/src/test/kotlin/dev/hossain/example/DatabaseSchemaTest.kt`, [[1]](diffhunk://#diff-caf2f555dddebaef52e009cc1ed674d78ebca25eb7ae58b40e54f70c20c1cc26L32-R40) [[2]](diffhunk://#diff-caf2f555dddebaef52e009cc1ed674d78ebca25eb7ae58b40e54f70c20c1cc26L49-R49) [[3]](diffhunk://#diff-caf2f555dddebaef52e009cc1ed674d78ebca25eb7ae58b40e54f70c20c1cc26L70-R78) [[4]](diffhunk://#diff-caf2f555dddebaef52e009cc1ed674d78ebca25eb7ae58b40e54f70c20c1cc26L89-R90)

### Updates to Sample Code:

- **Main Application**: Updated references to `csvValue` in `Main.kt` to use the renamed `value` property for form factor counts and database record processing. (`sample/src/main/java/dev/hossain/example/Main.kt`, [[1]](diffhunk://#diff-19b4fa5f5808ca842f1060c7a92b27737e937b82104ffcf10fff07cacf74a4ccL53-R53) [[2]](diffhunk://#diff-19b4fa5f5808ca842f1060c7a92b27737e937b82104ffcf10fff07cacf74a4ccL98-R98)