### PR TITLE
[FIXED] POM version issue

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -27,8 +27,8 @@ repositories {
 }
 
 dependencies {
-    // Align versions of all Kotlin components
-    implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
+    // Align versions of all Kotlin components - explicitly specify version to avoid POM issues
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom:2.2.0"))
 
     // CSV Processor
     // https://github.com/jsoizo/kotlin-csv (note: ownership changed from doyaaaaaken to jsoizo in v1.10.0)
@@ -55,7 +55,7 @@ publishing {
         create<MavenPublication>("maven") {
             groupId = "dev.hossain.android"
             artifactId = "catalogparser"
-            version = "1.4"
+            version = "1.8"
 
             from(components["java"])
         }


### PR DESCRIPTION
The error `Required version must not be null` is caused by the `<dependencyManagement>` section in your POM, specifically the imported `kotlin-bom` dependency. Gradle (and JitPack) expects all imported dependencies to have a valid version, but the second `kotlin-bom` dependency is missing a version or is incorrectly specified.

**How to fix:**

Remove the `<dependencyManagement>` section from your POM, or at least the problematic imported BOM dependency. You do not need `<dependencyManagement>` for a simple library published via JitPack.

**Fixed POM example:**

```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.github.hossain-khan</groupId>
  <artifactId>android-device-catalog-parser</artifactId>
  <version>1.7</version>
  <name>hossain-khan/android-device-catalog-parser</name>
  <description>Android Device catalog CSV parser that is available from Google Play developer console.</description>
  <url>https://github.com/hossain-khan/android-device-catalog-parser</url>
  <inceptionYear>2020</inceptionYear>
  <licenses>
    <license>
      <name>Apache License 2.0</name>
      <url>https://api.github.com/licenses/apache-2.0</url>
      <distribution>repo</distribution>
    </license>
  </licenses>
  <developers>
    <developer>
      <id>hossain-khan</id>
      <name>Hossain Khan</name>
      <email>hello@hossain.dev</email>
    </developer>
  </developers>
  <scm>
    <connection>scm:git://github.com/hossain-khan/android-device-catalog-parser.git</connection>
    <developerConnection>scm:git://github.com/hossain-khan/android-device-catalog-parser.git</developerConnection>
    <url>git://github.com/hossain-khan/android-device-catalog-parser.git</url>
  </scm>
  <dependencies>
    <dependency>
      <groupId>org.jetbrains.kotlin</groupId>
      <artifactId>kotlin-stdlib</artifactId>
      <version>2.2.0</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.jsoizo</groupId>
      <artifactId>kotlin-csv-jvm</artifactId>
      <version>1.10.0</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>
</project>
```

**Summary:**
Remove the `<dependencyManagement>` section or ensure all imported dependencies have valid versions. Rebuild and republish your library to JitPack. This should resolve the Gradle error.